### PR TITLE
feat: Login calls an API for authorization

### DIFF
--- a/FolketsHusApp/FolketsHusApp.csproj
+++ b/FolketsHusApp/FolketsHusApp.csproj
@@ -74,6 +74,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FolketsHusApp/Platforms/Android/AndroidManifest.xml
+++ b/FolketsHusApp/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application 
+		android:allowBackup="true" 
+		android:icon="@mipmap/appicon" 
+		android:roundIcon="@mipmap/appicon_round" 
+		android:supportsRtl="true" 
+		android:usesCleartextTraffic="true">
+		
+	</application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/FolketsHusApp/ViewModel/LoginViewModel.cs
+++ b/FolketsHusApp/ViewModel/LoginViewModel.cs
@@ -1,13 +1,37 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using FolketsHusApp.Pages;
+using Newtonsoft.Json;
+using System.Diagnostics;
+using System.Text;
+using System.Xml.Serialization;
 
 namespace FolketsHusApp.ViewModel;
+
+internal class LoginParams {
+    /// <summary>
+    /// Password used for access to the app
+    /// </summary>
+    [JsonProperty("password")]
+    public string Password { get; set; } = string.Empty;
+}
+
+internal class LoginResponse {
+    /// <summary>
+    /// Response status of request
+    /// </summary>
+    [JsonProperty("status")]
+    [SoapAttribute(AttributeName = "Status")]
+    public string Status { get; set; } = "400";
+}
 
 public partial class LoginViewModel : ObservableObject {
 
     IConnectivity connectivity;
     private readonly INavigationService navigationService;
+
+    // IMPORTANT! Change "http" to "https" when deployed and SSL Certificate is created.
+    // Change Url to webdomain when ready for production.
+    private readonly string apiUrl = "http://10.0.2.2:5100/api/appAuth";
 
     public LoginViewModel(IConnectivity connectivity, INavigationService navigationService) {
         this.connectivity = connectivity;
@@ -24,15 +48,30 @@ public partial class LoginViewModel : ObservableObject {
         if (string.IsNullOrWhiteSpace(EnteredPassword))
             return;
 
-        if (connectivity.NetworkAccess != NetworkAccess.Internet) {
-            await Shell.Current.DisplayAlert("Error", "No Internet Access. Try again later", "OK");
+        else if (connectivity.NetworkAccess != NetworkAccess.Internet) {
+            // NO LONGER WORKS!!! Implement a custom alert lable on the page.
+            //await Shell.Current.DisplayAlert("Error", "No Internet Access. Try again later", "OK");
             return;
+        } else {
+
+            var httpClient = new HttpClient();
+            var loginParams = new LoginParams { Password = EnteredPassword };
+            var content = new StringContent(JsonConvert.SerializeObject(loginParams), Encoding.UTF8, "application/json");
+
+            HttpResponseMessage response = await httpClient.PostAsync(apiUrl, content);
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK) {
+                Debug.WriteLine($"Request called successfully, but failed on the server, Error code: {response.StatusCode}");
+                return;
+            } else {
+                Debug.WriteLine("Request successfull, should redirect");
+                await navigationService.GoToAsync($"//{nameof(Pages.HomePage)}");
+                return;
+            }
+
         }
 
-        if (EnteredPassword != password)
-            return;
-
-        await navigationService.GoToAsync($"//{nameof(HomePage)}");
     }
-
 }


### PR DESCRIPTION
When attempting to log in, the LoginViewModel make a POST request to the appAuth API on the webserver. If response has a status code of 200 (OK), the user is redirected to the shell and home page.

Future work: The appAuth API will return an AccessToken and a RefreshToken. This should be used to authenticate the user every time they make an API call to either get data from the database, or to send data to the webserver.

Closes #1