### PR TITLE
bug: Detail Page Genres Modal now closes

### DIFF
--- a/FolketsHusApp/AppShell.xaml.cs
+++ b/FolketsHusApp/AppShell.xaml.cs
@@ -6,17 +6,17 @@ namespace FolketsHusApp {
         public AppShell() {
             InitializeComponent();
 
-            Routing.RegisterRoute(nameof(HomePage), typeof(HomePage));
-            Routing.RegisterRoute(nameof(BioRosenQuickPage), typeof(BioRosenQuickPage));
-            Routing.RegisterRoute(nameof(BioRosenFilmPage), typeof(BioRosenFilmPage));
-            Routing.RegisterRoute(nameof(BioRosenLivePage), typeof(BioRosenLivePage));
-            Routing.RegisterRoute(nameof(BioRosenKontrastPage), typeof(BioRosenKontrastPage));
-            Routing.RegisterRoute(nameof(UnesPage), typeof(UnesPage));
-            Routing.RegisterRoute(nameof(EvenemangPage), typeof(EvenemangPage));
+            //Routing.RegisterRoute(nameof(HomePage), typeof(HomePage));
+            //Routing.RegisterRoute(nameof(BioRosenQuickPage), typeof(BioRosenQuickPage));
+            //Routing.RegisterRoute(nameof(BioRosenFilmPage), typeof(BioRosenFilmPage));
+            //Routing.RegisterRoute(nameof(BioRosenLivePage), typeof(BioRosenLivePage));
+            //Routing.RegisterRoute(nameof(BioRosenKontrastPage), typeof(BioRosenKontrastPage));
+            //Routing.RegisterRoute(nameof(UnesPage), typeof(UnesPage));
+            //Routing.RegisterRoute(nameof(EvenemangPage), typeof(EvenemangPage));
 
-            Routing.RegisterRoute(nameof(FilmDetailPage), typeof(FilmDetailPage));
+            //Routing.RegisterRoute(nameof(FilmDetailPage), typeof(FilmDetailPage));
 
-            Routing.RegisterRoute(nameof(LogoutSubPage), typeof(LogoutSubPage));
+            //Routing.RegisterRoute(nameof(LogoutSubPage), typeof(LogoutSubPage));
         }
     }
 }

--- a/FolketsHusApp/MauiProgram.cs
+++ b/FolketsHusApp/MauiProgram.cs
@@ -38,9 +38,6 @@ namespace FolketsHusApp {
                 .AddTransient<BioRosenKontrastPage>()
                 .AddTransient<BioRosenKontrastViewModel>()
 
-                .AddTransient<FilmDetailPage>()
-                .AddTransient<FilmDetailViewModel>()
-
                 .AddTransient<UnesPage>()
                 .AddTransient<UnesViewModel>()
 

--- a/FolketsHusApp/Pages/FilmDetailPage.xaml
+++ b/FolketsHusApp/Pages/FilmDetailPage.xaml
@@ -32,12 +32,12 @@
 
             <Button
                 Grid.ColumnSpan="3"
-                Text="SAVE"
+                Text="BACK"
                 VerticalOptions="Center"
                 HorizontalOptions="Center"
                 WidthRequest="200"
-                BackgroundColor="LightSkyBlue"
-                Command="{Binding SaveCommand}"/>
+                BackgroundColor="LightSlateGray"
+                Command="{Binding BackCommand}"/>
 
             <Label 
                 Grid.Row="1"

--- a/FolketsHusApp/Pages/FilmDetailPage.xaml.cs
+++ b/FolketsHusApp/Pages/FilmDetailPage.xaml.cs
@@ -1,12 +1,12 @@
+using FolketsHusApp.Models;
 using FolketsHusApp.ViewModel;
 
 namespace FolketsHusApp.Pages;
 
 public partial class FilmDetailPage : ContentPage {
 
-    public FilmDetailPage(FilmDetailViewModel vm) {
+    public FilmDetailPage(FilmObject filmObject) {
         InitializeComponent();
-        BindingContext = vm;
-
+        BindingContext = new FilmDetailViewModel(filmObject);
     }
 }

--- a/FolketsHusApp/ViewModel/BioRosenFilmViewModel.cs
+++ b/FolketsHusApp/ViewModel/BioRosenFilmViewModel.cs
@@ -119,11 +119,13 @@ public partial class BioRosenFilmViewModel : ObservableObject {
 
         FilmObject filmObject = obj as FilmObject;
 
-        var navigationParameter = new Dictionary<string, object> {
-            { "FilmObject", filmObject }
-        };
+        //var navigationParameter = new Dictionary<string, object> {
+        //    { "FilmObject", filmObject }
+        //};
 
-        await Shell.Current.GoToAsync(nameof(FilmDetailPage), navigationParameter);
+        //await Shell.Current.GoToAsync(nameof(FilmDetailPage), navigationParameter);
+
+        await Application.Current.MainPage.Navigation.PushModalAsync(new FilmDetailPage(filmObject));
     }
 
 }

--- a/FolketsHusApp/ViewModel/FilmDetailViewModel.cs
+++ b/FolketsHusApp/ViewModel/FilmDetailViewModel.cs
@@ -6,8 +6,7 @@ using System.Diagnostics;
 
 namespace FolketsHusApp.ViewModel;
 
-[QueryProperty(nameof(FilmObject), "FilmObject")]
-public partial class FilmDetailViewModel : ObservableObject, IQueryAttributable, INotifyPropertyChanged {
+public partial class FilmDetailViewModel : ObservableObject {
 
     public FilmObject? filmObject { get; private set; }
 
@@ -43,10 +42,7 @@ public partial class FilmDetailViewModel : ObservableObject, IQueryAttributable,
     [ObservableProperty]
     public List<int> genresIndices = new List<int>();
 
-
-    public void ApplyQueryAttributes(IDictionary<string, object> query) {
-        filmObject = query["FilmObject"] as FilmObject;
-        OnPropertyChanged("FilmObject");
+    public FilmDetailViewModel(FilmObject filmObject) {
 
         if (filmObject != null) {
             FilmTitle = filmObject.FilmName;
@@ -88,7 +84,6 @@ public partial class FilmDetailViewModel : ObservableObject, IQueryAttributable,
 
             IsPremiere = filmObject.IsPremiere;
         }
-
     }
 
     [RelayCommand]
@@ -126,5 +121,13 @@ public partial class FilmDetailViewModel : ObservableObject, IQueryAttributable,
     [RelayCommand]
     void Save() {
 
+    }
+
+    [RelayCommand]
+    async Task Back() {
+        if (Application.Current != null && Application.Current.MainPage != null)
+            await Application.Current.MainPage.Navigation.PopModalAsync();
+
+        return;
     }
 }


### PR DESCRIPTION
Removed double route registration in AppShell xaml and cs, which was the root of the bug.

Improved general structure. Detail page is now also a modal page, that builds a new viewmodel on creation. The VM constructor is the same as the previous query parser.

Because the detail page is now a modal page, it no longer needs to be registered as a navigation route, and therefore doesn't need to be added to the MauiProgram.cs builder.

Furthermore, being a modal page, it does not have a built-in shell navigation back button. Thus, the Android built-in back button is the only remaining option to navigate back from the Modal. So for future cross-platform compatability, the top SAVE button has been switched into a BACK button, since having two save buttons is redundant anyway.

Closes #19 